### PR TITLE
ci: attest SLSA build provenance for release zips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -202,7 +204,13 @@ jobs:
         draft: false
         prerelease: false
         files: Crosspaths-${{ steps.version.outputs.version }}.zip
-        
+
+    - name: Attest build provenance
+      if: steps.check_tag.outputs.exists == 'false'
+      uses: actions/attest-build-provenance@v4
+      with:
+        subject-path: Crosspaths-${{ steps.version.outputs.version }}.zip
+
     - name: Convert interface version to game version
       if: steps.check_tag.outputs.exists == 'false'
       id: game_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@ on:
 
 permissions:
   contents: write
-  id-token: write
-  attestations: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Adds SLSA build provenance to the release workflow so the published zip can be
cryptographically verified back to the workflow run that built it.

## What changed
- Grant the release job `id-token: write` and `attestations: write` (alongside the existing `contents: write`).
- Add an `actions/attest-build-provenance@v4` step that attests the packaged zip after the GitHub Release is created.

No change to packaging, CurseForge upload, or the release trigger. The attest
step is gated by the same `check_tag` condition as the rest of the release, so
it only runs on a new version.

## Verify after the next release
```sh
gh release download <tag> --repo djdefi/crosspaths -p "*.zip" -D /tmp/v
gh attestation verify /tmp/v/*.zip --repo djdefi/crosspaths
```

This is the same check addon managers like Runehold run under
`verify --attestation`, so the released zip reports "attestation verified"
instead of "absent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
